### PR TITLE
kapitlet -> kapittelet

### DIFF
--- a/innhold/ekstra/terminal.md
+++ b/innhold/ekstra/terminal.md
@@ -293,7 +293,7 @@ kurs $> ls -lh
 
 Tilvalg skal som regel plasseres rett etter navnet på programmet du kjører, men rekkefølgen på dem spiller ingen rolle.
 
-Tilvalgene som er vist i dette delkapitlet tar ikke inn noen tilhørende verdi.
+Tilvalgene som er vist i dette delkapittelet tar ikke inn noen tilhørende verdi.
 De kalles også for _flagg_.
 
 

--- a/innhold/kap1/1_kjøre_pythonprogram.md
+++ b/innhold/kap1/1_kjøre_pythonprogram.md
@@ -1,6 +1,6 @@
 Kjøre Python-kode
 =================
-**💡 Læringsmål:** _I dette kapitlet skal du lære deg hvordan du får datamaskinen din til å kjøre Python-kode._
+**💡 Læringsmål:** _I dette kapittelet skal du lære deg hvordan du får datamaskinen din til å kjøre Python-kode._
 
 Når man lærer seg et programmeringsspåk, er ofte det første programmet man skrivet et [«Hallo, verden»-program](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program). Dette er helt enkelt et program som skriver ut teksten «Hallo, verden». La oss skrive et sånt program sammen!
 
@@ -251,7 +251,7 @@ Alle tre er lisensiert under [Creative Commons BY-SA](https://creativecommons.or
 Selve Python-språket er det samme, uansett om du kjører Python-fortolkeren interaktivt i terminalen eller du skriver koden i et skript som du ber fortolkeren om å tolke.
 Du _kan_ i teorien sitte og ta én og én linje fra et Python-skript og fôre dem til en interaktiv Python-sesjon, og resultatet vil bli nøyaktig det samme.
 
-**NB**: I dette kapitlet har vi brukt begrepet _Python-fortolker_ om dataprogrammet som tolker og kjører Python-koden den blir gitt, og _Python-skript_ om `.py`-filene som inneholder Python-kode.
+**NB**: I dette kapittelet har vi brukt begrepet _Python-fortolker_ om dataprogrammet som tolker og kjører Python-koden den blir gitt, og _Python-skript_ om `.py`-filene som inneholder Python-kode.
 I resten av kurset kan vi finne på å si at «Vi lager et program som skal lese en tekstfil», og bruker «program» og «(Python-)skript» om hverandre.
 Når vi bare snakker om «Python» kan vi referere til språket eller til Python-fortolkeren.
 

--- a/innhold/kap1/2_kommentarer.md
+++ b/innhold/kap1/2_kommentarer.md
@@ -1,6 +1,6 @@
 Kommentarer
 ===========
-**💡 Læringsmål:** _I dette kapitlet skal du lære deg å skrive forklaringer som kan bo sammen med koden._
+**💡 Læringsmål:** _I dette kapittelet skal du lære deg å skrive forklaringer som kan bo sammen med koden._
 
 Korte kommentarer
 -----------------

--- a/innhold/kap1/3_enkle_datastrukturer_og_variabler.md
+++ b/innhold/kap1/3_enkle_datastrukturer_og_variabler.md
@@ -1,10 +1,10 @@
 Enkle datastrukturer og variabler
 =================================
-**💡 Læringsmål:** _I dette kapitlet skal du lære deg å bruke enkle datastrukturer som tall, tekst og boolske verdier. I tillegg skal vi se litt på variabler._
+**💡 Læringsmål:** _I dette kapittelet skal du lære deg å bruke enkle datastrukturer som tall, tekst og boolske verdier. I tillegg skal vi se litt på variabler._
 
 Når vi snakker om datastrukturer, snakker vi i grove trekk om mekanismene vi bruker for å organiserer data i et dataprogram. Ofte skiller vi mellom enkle datastrukturer, som typisk er bygget inn i programmeringsspråket, og mer avanserte datastrukturer, hvor programmereren selv bygger datastrukturen basert på egendefinerte klasser, objekter og funksjoner.
 
-I dette kapitlet skal vi se på enkle datastrukturer som tall, strenger (tekst) og boolske verdier (sant og falskt). I tillegg skal vi se på variabler, som lar oss referere til dataverdier med navn.
+I dette kapittelet skal vi se på enkle datastrukturer som tall, strenger (tekst) og boolske verdier (sant og falskt). I tillegg skal vi se på variabler, som lar oss referere til dataverdier med navn.
 
 _**Tips:** Når du går gjennom dette kapittelet, kan det være lurt å lage en kodefil som heter `datastrukturer.py` i mappen `kurs/`, og bruke denne til å teste ut de forskjellige kodesnuttene du støter på._
 

--- a/innhold/kap1/4_samlinger.md
+++ b/innhold/kap1/4_samlinger.md
@@ -1,6 +1,6 @@
 Samlinger
 =========
-**💡 Læringsmål:** _I dette kapitlet skal du lære deg å bruke datastrukturer som samler flere elementer til et sett med informasjon._
+**💡 Læringsmål:** _I dette kapittelet skal du lære deg å bruke datastrukturer som samler flere elementer til et sett med informasjon._
 
 Datastrukturer regnes som noe av det mest grunnleggende innenfor programmering. Man samler data i en spesifikk struktur, derav selve beskrivelsen. 
 Mye av styrken kommer av mulighetene man har til å utføre bestemte operasjoner på den lagrede dataen, på en veldig effektiv måte; _gjør X operasjon på alle elementene i lista_

--- a/innhold/kap1/5_input.md
+++ b/innhold/kap1/5_input.md
@@ -1,7 +1,7 @@
 Input
 =====
 
-**💡 Læringsmål:** _I dette kapitlet vil du lære å ta inn data fra brukeren._
+**💡 Læringsmål:** _I dette kapittelet vil du lære å ta inn data fra brukeren._
 
 Fram til nå har vi skrevet tekst fra programmet til terminalen.
 Men hvis du har villet endre hvilke verdier programmet ditt opererte på,
@@ -267,7 +267,7 @@ Skriv av `input_ja_nei_v0.py` ovenfor.
 Har du lyst til å prøve deg på å endre definisjonen av `vil_fortsette_tolket` sånn at den blir `True` eller `False` etter reglene ovenfor?
 Du kan for eksempel starte med én regel og se at den blir riktig, før du prøver deg på neste regel – likt hvordan du løser én side av en Rubiks kube først.
 
-Hvis du merker at du er litt lite inspirert akkurat nå, kan du bare hoppe over oppgaven – resten av dette kapitlet er dedikert til hvordan den kan løses.
+Hvis du merker at du er litt lite inspirert akkurat nå, kan du bare hoppe over oppgaven – resten av dette kapittelet er dedikert til hvordan den kan løses.
 
 
 #### Runde 1: Godta kun y som «ja»

--- a/innhold/kap1/6_hvis_omatte_og_ellers.md
+++ b/innhold/kap1/6_hvis_omatte_og_ellers.md
@@ -1,7 +1,7 @@
 Hvis, omatte og ellers
 ======================
 
-**💡 Læringsmål:** _I dette kapitlet skal du lære deg å skrive kode som gjør valg._
+**💡 Læringsmål:** _I dette kapittelet skal du lære deg å skrive kode som gjør valg._
 
 Hittil har programmene våre kjørt fra topp til bunn:
 Så snart det har gjort seg ferdig med én instruks,

--- a/innhold/kap1/7_løkker.md
+++ b/innhold/kap1/7_løkker.md
@@ -1,7 +1,7 @@
 Løkker
 ======
 
-**💡 Læringsmål:** _I dette kapitlet skal du lære deg å bruke løkker for å gjøre ting flere ganger._
+**💡 Læringsmål:** _I dette kapittelet skal du lære deg å bruke løkker for å gjøre ting flere ganger._
 
 Løkker lar deg gjøre handlinger og operasjoner flere ganger, for eksempel ved å itere over alle elementene i en samling og slette elementene som matcher et spesifikt kriterie.
 Vi skal se på to typer løkker, nemlig for-løkker og while-løkker.

--- a/innhold/kap1/8_funksjoner.md
+++ b/innhold/kap1/8_funksjoner.md
@@ -1,6 +1,6 @@
 Funksjoner
 ==========
-**💡 Læringsmål:** _I dette kapitlet skal du lære å lage funksjoner slik at du kan dele opp koden i mindre biter og kan bruke samme kodebit flere steder._
+**💡 Læringsmål:** _I dette kapittelet skal du lære å lage funksjoner slik at du kan dele opp koden i mindre biter og kan bruke samme kodebit flere steder._
 
 ## Hva er en funksjon?
 

--- a/innhold/kap2/1_lese_fil.md
+++ b/innhold/kap2/1_lese_fil.md
@@ -1,7 +1,7 @@
 Vi leser data fra en fil
 ========================
 
-**💡 Læringsmål:** _I dette kapitlet lærer du hvordan du leser data fra en fil._
+**💡 Læringsmål:** _I dette kapittelet lærer du hvordan du leser data fra en fil._
 
 
 Lag deg en `.py`-fil som du vil skrive programmet ditt i, og kopier fila [serier.txt](filer/serier.txt) til samme mappe som Python-filen.

--- a/innhold/kap2/2_skrive_fil.md
+++ b/innhold/kap2/2_skrive_fil.md
@@ -1,7 +1,7 @@
 Vi skriver data til en fil
 ==========================
 
-**💡 Læringsmål:** _I dette kapitlet lærer du hvordan du skriver data til en fil._
+**💡 Læringsmål:** _I dette kapittelet lærer du hvordan du skriver data til en fil._
 
 Å skrive til fil ligner mye på å lese fra fil, men når vi åpner fila må vi bruke riktig modus, enten `w` (_write_) eller `a` (_append_). Forskjellen på dem er at når fila åpnes med `w` vil det eksisterende innholdet i fila slettes, mens `a` beholder innholdet, slik at nye ting som skrives legges til på slutten av fila. Og i stedet for å bruke `read()` for å lese fila, må vil bruke `write()` for å skrive.
 ```python

--- a/innhold/kap2/3_feilhåndtering.md
+++ b/innhold/kap2/3_feilhåndtering.md
@@ -1,7 +1,7 @@
 Feilhåndtering
 ==============
 
-**💡 Læringsmål:** _I dette kapitlet lærer du hvordan du kan håndtere feil som oppstår når programmet kjører, og dermed unngå at programmet kræsjer uventet._
+**💡 Læringsmål:** _I dette kapittelet lærer du hvordan du kan håndtere feil som oppstår når programmet kjører, og dermed unngå at programmet kræsjer uventet._
 
 ## Prøv og feil
 

--- a/innhold/kap2/4_json.md
+++ b/innhold/kap2/4_json.md
@@ -1,7 +1,7 @@
 JSON: Et dataformat
 ===================
 
-**💡 Læringsmål:** _I dette kapitlet lærer du hva JSON er og hvordan formatet er strukturert, samt hvordan man kan lese og skrive JSON til og fra fil._
+**💡 Læringsmål:** _I dette kapittelet lærer du hva JSON er og hvordan formatet er strukturert, samt hvordan man kan lese og skrive JSON til og fra fil._
 
 JSON står for "JavaScript Object Notation" og er et tekstformat som er relativt leselig for mennesker, og enda enklere for maskiner å lese. Det er basert på JavaScript, men er ellers språkuavhengig.
 

--- a/innhold/kap2/5_oppgave.md
+++ b/innhold/kap2/5_oppgave.md
@@ -1,7 +1,7 @@
 Lek og Moro med Elektronisk Program-Guide!
 ==========================================
 
-**💡 Læringsmål:** _I dette kapitlet lærer du hvordan enkeltdelene i de foregående kapitlene kan settes sammen og bli til et nyttig program_
+**💡 Læringsmål:** _I dette kapittelet lærer du hvordan enkeltdelene i de foregående kapitlene kan settes sammen og bli til et nyttig program_
 
 Vi skal i korte trekk lage et skript som:
 1. Leser inn Elektronisk Program-Guide (EPG) for flere kanaler fra en JSON-fil.

--- a/innhold/kap3/2_kommandolinjeargumenter.md
+++ b/innhold/kap3/2_kommandolinjeargumenter.md
@@ -2,7 +2,7 @@ Kommandolinje-argumenter
 ========================
 
 **💡 Læringsmål:**
-_I dette kapitlet skal du bli kjent med hvordan du kan gi brukeren kontroll
+_I dette kapittelet skal du bli kjent med hvordan du kan gi brukeren kontroll
 over hva applikasjonen skal gjøre, uten at applikasjonen stopper opp underveis._
 
 Når vi skriver kommandolinjeprogram for et visst publikum så må vi tenke på _brukeropplevelsen_ for de som bruker programmet vårt.
@@ -11,7 +11,7 @@ Men du risikerer selv å bli en nybegynner på programmet ditt når det har gåt
 og alle minner om hvordan det fungerte for lengst har forduftet.
 
 Brukergrensesnittet til kommandolinjeprogram kalles [_the command-line interface (CLI)_][wiki-cli] på engelsk.
-I dette kapitlet ser vi på ett av mange aspekter ved CLI.
+I dette kapittelet ser vi på ett av mange aspekter ved CLI.
 
 Hvis det er uvant å bruke kommandolinja/terminalen, så kan det hende du har lyst til å lese [ekstra-seksjonen om terminalen](../ekstra/terminal.md).
 
@@ -106,7 +106,7 @@ og så gjøre noe annet mens programmet kjører.
 
 ### Gi verdien samtidig som du starter programmet
 
-I resten av dette kapitlet skal vi se på _kommandolinjeargumenter_.
+I resten av dette kapittelet skal vi se på _kommandolinjeargumenter_.
 Dette er verdier som brukeren skriver samtidig som hen starter programmet ditt.
 For eksempel:
 

--- a/innhold/kap3/3_api.md
+++ b/innhold/kap3/3_api.md
@@ -2,7 +2,7 @@ Applikasjonsprogrammeringsgrensesnitt (API)
 ===========================================
 
 **💡 Læringsmål:**
-_I dette kapitlet lærer du hva et API er og hva det benyttes til, og hvilke muligheter Python har til å arbeide med et API_
+_I dette kapittelet lærer du hva et API er og hva det benyttes til, og hvilke muligheter Python har til å arbeide med et API_
 
 ## Hva er et API?
 API står for "Application Programming Interface" og kan defineres som et set med protokoller, definisjoner og verktøy for å bygge og integrere applikasjonsprogramvare.
@@ -14,7 +14,7 @@ tilsvarende kelneren som kommer med maten når kokken har tilberedt den.
 
 
 ## HTTP-meldinger
-En type API som vi skal se på og lære mer om i dette kapitlet er web-API.
+En type API som vi skal se på og lære mer om i dette kapittelet er web-API.
 
 Web-API som benytter HTTP sender meldinger som følger en bestemt standard, og kan deles inn i to typer; forespørsler og responser (`request` og `response`). Forespørslene er meldingene som sendes til API'et, mens responsen er svaret som API'et gir til klienten som sendte forespørselen.
 

--- a/innhold/kap3/4_organisering.md
+++ b/innhold/kap3/4_organisering.md
@@ -1,7 +1,7 @@
 Organisering med moduler og pakker
 ==================================
 
-**💡 Læringsmål:** _I dette kapitlet lærer du hvordan du kan organisere koden på en strukturert måte så det blir lettere å finne fram_
+**💡 Læringsmål:** _I dette kapittelet lærer du hvordan du kan organisere koden på en strukturert måte så det blir lettere å finne fram_
 
 ## Moduler
 

--- a/innhold/kap3/5_oppgave.md
+++ b/innhold/kap3/5_oppgave.md
@@ -1,7 +1,7 @@
 Mer lek og moro med Elektronisk Program-Guide!
 ==========================================
 
-**💡 Læringsmål:** _I dette kapitlet vil du lære hvordan enkeltdelene fra de foregående kapitlene kan brukes sammen for å utvide og forbedre EPG-programmet_
+**💡 Læringsmål:** _I dette kapittelet vil du lære hvordan enkeltdelene fra de foregående kapitlene kan brukes sammen for å utvide og forbedre EPG-programmet_
 
 Nå som vi både har lært om kommandolinjeargumenter, kan hente data fra API , og kan lage moduler og pakker, kan vi forbedre programmet fra [kapittel 2.5](../kap2/5_oppgave.md).
 

--- a/innhold/kap4/1_objektorientering.md
+++ b/innhold/kap4/1_objektorientering.md
@@ -1,5 +1,5 @@
 # Objektorientert programmering i Python
-**💡 Læringsmål:** _I dette kapitlet skal du lære om objektorientert programmering og hvordan du kan skrive dine egne klasser for å binde sammen egenskaper og oppførsel i objekter_
+**💡 Læringsmål:** _I dette kapittelet skal du lære om objektorientert programmering og hvordan du kan skrive dine egne klasser for å binde sammen egenskaper og oppførsel i objekter_
 
 Python er et **objektorientert språk(OOP)**, som betyr at et program er strukturert slik at egenskaper og oppførsel er representert i objekter. Et objekt kan for eksempel representere et menneske med egenskaper som navn, alder eller by og oppførsel som for eksempel å gå, snakke eller puste. Eller det kan representere en handlekurv med egenskaper som beskriver hvilke varer som er i handlekurven og oppførsel for å legge til eller fjerne varer. Også typer som du har lært om tidligere, som for eksempel strenger, tall og lister, er representert som objekter i Python.
 

--- a/innhold/kap4/3_simplegui.md
+++ b/innhold/kap4/3_simplegui.md
@@ -1,6 +1,6 @@
 Grafiske brukergrensesnitt med PySimpleGUI
 ==========================================
-**💡 Læringsmål:** _I dette kapitlet lærer du litt om hva grafiske brukergrensesnitt er, og du får laget ditt første grafiske brukergrensesnitt med PySimpleGUI._
+**💡 Læringsmål:** _I dette kapittelet lærer du litt om hva grafiske brukergrensesnitt er, og du får laget ditt første grafiske brukergrensesnitt med PySimpleGUI._
 
 Hva er et grafisk brukergrensesnitt?
 ------------------------------------

--- a/innhold/prosjektoppgave/README.md
+++ b/innhold/prosjektoppgave/README.md
@@ -1,6 +1,6 @@
 # Prosjektoppgave 🎉
 
-**💡 Læringsmål:** _I dette kapitlet er målet at du bruker mye av det du har lært hittil i et større prosjekt. Vi har samlet noen forslag til prosjekt du kan jobbe med, resten opp til deg! 🌟_
+**💡 Læringsmål:** _I dette kapittelet er målet at du bruker mye av det du har lært hittil i et større prosjekt. Vi har samlet noen forslag til prosjekt du kan jobbe med, resten opp til deg! 🌟_
 
 ## Tips
 


### PR DESCRIPTION
En kursdeltaker gjorde meg oppmerksom på at det har kommet noen nye språkregler, blant annet er ikke lenger den sammentrukne formen av kapittel i bestemt form entall tillatt, så har endret fra kapitlet til kapittelet. 
 https://www.sprakradet.no/Vi-og-vart/hva-skjer/Aktuelt/2023/endringer-i-boyningen-av-en-del-intetkjonnssubstantiver-i-bokmal/